### PR TITLE
Update GAPI invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ client.login(); // connect to the guilded gateway
 
 ## Support
 
-You may get support in the [Unofficial Guilded API](https://guilded.ga/api) server.
+You may get support in the [Unofficial Guilded API](https://community.guildedapi.com) server.
 
 You will have to then go to `#roles` and then press `guilded.gg.js` and add yourself to the role.
 


### PR DESCRIPTION
I own the guilded.ga domain. It will expire soon (August?), and I don't plan on renewing it. I do appreciate the use of my domain (that unfortunately I didn't do much with), but to prevent a dead link in the future, the link should be updated to the current redirect URL. You could also use the vanity on guilded.gg - `guilded-api` - if you prefer.